### PR TITLE
Add Apache-2.0 licensing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,11 +7,20 @@
     <Authors>AvaScope contributors</Authors>
     <Company>AvaScope</Company>
     <Product>AvaScope</Product>
+    <Copyright>Copyright © 2026 AvaScope contributors</Copyright>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/RolandUI/AvaScope</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/RolandUI/AvaScope.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)NOTICE" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE-SCOPE.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)THIRD-PARTY-NOTICES.md" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-SCOPE.md
+++ b/LICENSE-SCOPE.md
@@ -1,0 +1,13 @@
+# AvaScope License Scope
+
+Copyright 2026 AvaScope contributors.
+
+Unless a file or release explicitly states otherwise, the Apache License 2.0 in [LICENSE](LICENSE) applies to:
+
+- AvaScope-authored source code and documentation in this repository;
+- official AvaScope NuGet packages published by the `RolandUI` account; and
+- official AvaScope executable and GitHub release artifacts published by the `RolandUI` account.
+
+This license grant includes official AvaScope versions 0.1.0 and later, including versions published before the repository received its root license file.
+
+This grant does not relicense third-party code, libraries, fonts, native binaries, trademarks, or other materials. Those components remain under their respective licenses and notices, including the materials listed in [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md).

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+AvaScope
+Copyright 2026 AvaScope contributors
+
+This product includes software developed by AvaScope contributors and
+separately licensed third-party components listed in THIRD-PARTY-NOTICES.md.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Executable ZIPs and package artifacts are published from GitHub Releases when a 
 - MCP is a thin adapter over reusable local libraries and uses structured results instead of unbounded UI payloads.
 - Runtime control is intentionally narrow, local-only, and non-destructive in the stable v1 surface. Bridge-enabled apps support bounded reversible temporary UI mutations for selected style, layout, text, class, and resource experiments, plus before/after evidence capture, session-local mutation review, and reset/close cleanup for agent review loops.
 
+## License
+
+AvaScope-authored source code and official AvaScope release artifacts published by RolandUI, including previously published official releases, are licensed under the [Apache License 2.0](LICENSE). See [LICENSE-SCOPE.md](LICENSE-SCOPE.md) for the exact scope of the grant and [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for separately licensed dependencies.
+
 ## Project Status
 
 AvaScope `v1.0.0` is the stable agent control-plane release. Package identities, protocol DTOs, CLI commands, MCP tools, exit codes, artifact names, and release workflow behavior are documented in [docs/STABLE_SURFACE.md](docs/STABLE_SURFACE.md).

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,85 @@
+# Third-Party Notices
+
+AvaScope NuGet packages reference third-party packages, and AvaScope executable ZIPs include restored third-party assemblies and native assets. Those components are not AvaScope-authored work and remain under their own licenses.
+
+The released dependency graph is authoritative for exact versions. The principal distributed dependency families for AvaScope 1.1.3 are:
+
+| Component family | Version line | License and notice source |
+| --- | --- | --- |
+| Avalonia, Avalonia Headless, Skia, HarfBuzz, XAML Loader, Fluent Theme, Remote Protocol and Fonts.Inter packages | 12.1.0 | MIT; copyright 2013-2026 The AvaloniaUI Project. See the [Avalonia license](https://github.com/AvaloniaUI/Avalonia/blob/12.1.0/licence.md) and [Avalonia third-party notice](https://github.com/AvaloniaUI/Avalonia/blob/12.1.0/NOTICE.md). |
+| Inter font files embedded by `Avalonia.Fonts.Inter` | Avalonia 12.1.0 asset set | SIL Open Font License 1.1; copyright 2016 The Inter Project Authors. Full text below. |
+| MicroCom.Runtime | 0.11.6 | MIT; copyright 2021 Nikita Tsukanov. |
+| SkiaSharp and native assets | 3.119.4 | MIT package license; copyright Xamarin, Inc. and Microsoft Corporation. Native components retain any additional notices shipped by their upstream packages. |
+| HarfBuzzSharp and native assets | 8.3.1.3 | MIT package license; copyright Xamarin, Inc. and Microsoft Corporation. Native components retain any additional notices shipped by their upstream packages. |
+| Microsoft.Extensions, Microsoft.Extensions.AI and System.Diagnostics.EventLog packages | 10.x | MIT; copyright Microsoft Corporation. |
+| ModelContextProtocol and ModelContextProtocol.Core | 1.4.0 | Package metadata declares Apache-2.0. The [upstream license](https://github.com/modelcontextprotocol/csharp-sdk/blob/v1.4.0/LICENSE) also documents an Apache-2.0 transition in which contributions not yet relicensed remain MIT. Both the repository Apache-2.0 text and the MIT text below accompany AvaScope distributions. |
+
+Package or native-asset notices that are more specific than this summary continue to apply. This file does not replace or narrow any upstream license.
+
+## MIT License Text
+
+The following standard MIT terms apply to the MIT-licensed component families identified above, together with their respective upstream copyright notices.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## SIL Open Font License 1.1
+
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+### PREAMBLE
+
+The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+### DEFINITIONS
+
+"Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting, or substituting -- in part or in whole -- any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+### PERMISSION AND CONDITIONS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+1. Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+2. Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+3. No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+4. The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+5. The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+### TERMINATION
+
+This license becomes null and void if any of the above conditions are not met.
+
+### DISCLAIMER
+
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -26,20 +26,22 @@ GitHub Issues and Milestones are the primary project-management source for auton
 
 ## Current Focus
 
-- `Release v1.1.2`
-- GitHub Issue: #64
-- GitHub Milestone: `v1.1.2`
-- Status: `Done`
+- `Release v1.1.3`
+- GitHub Issue: #65
+- GitHub Milestone: `v1.1.3`
+- Status: `Review`
 - Owner: autonomous agent
 - Started: `2026-07-10`
-- Goal: ship the completed diagnostics root-normalization fix on the latest stable Avalonia `12.1.0` runtime line through the guarded `v1.1.2` release workflow.
+- Goal: establish Apache-2.0 licensing for AvaScope-authored source and official releases, add verifiable package/release legal metadata, and publish the remediation through the guarded `v1.1.3` release workflow.
 
 ## Next Action
 
-No active `v1.1.2` release issue remains after publishing the release and closing #64 and the milestone.
+Merge the validated #65 licensing change, close the issue, then start release tracker #66.
 
 ## Latest Validation
 
+- `2026-07-10`: Completed local implementation for GitHub issue #65. Added the canonical Apache-2.0 license, an explicit license grant covering AvaScope-authored official releases from `0.1.0` onward, a project notice, third-party dependency notices, shared NuGet license/repository/copyright metadata, and packaged-output validation for NuGet and executable legal files. Debug build passed with 0 warnings and 0 errors; focused stable-surface tests passed (`4`); the full Debug suite passed (`370`); a Release packaging run with tests/sample smoke skipped produced and verified three NuGet packages plus Windows/Linux ZIPs; NuGet and GitHub Release dry-runs passed; and `git diff --check` passed with only line-ending normalization warnings. Issue #65 and its roadmap card moved to `Review / 75% / Current Slice`.
+- `2026-07-10`: Started GitHub issue #65 for the `v1.1.3` milestone after selecting Apache-2.0 for its permissive adoption model and explicit patent grant. The issue and roadmap card moved to `In Progress / 25% / Current Slice`; release tracker #66 is `Ready / 0% / Release Tracker`. Intended validation covers repository legal files, shared NuGet metadata, packed nuspec/legal-file inspection, executable ZIP notices, build, full tests, release dry-runs, and `git diff --check`.
 - `2026-07-10`: Published `v1.1.2` from release commit `ca3e49fd6e5c30709b7cf53cc5f1b13ae557e744` through Release workflow `29055197705` (`push`, success, 10m34s). The workflow published the three `1.1.2` packages to nuget.org and GitHub Packages, created tag `v1.1.2` at the release commit, and uploaded six GitHub Release assets. `gh release view`, `git ls-remote`, and the downloaded remote release manifest verified the public release, tag target, asset set, version, sizes, and SHA-256 digests; the public nuget.org flat-container index subsequently exposed `1.1.2` for Protocol, Core, and Bridge.
 - `2026-07-10`: Full local `v1.1.2` release gate passed after stopping 11 stale repository artifact-hosted MCP processes. Release build passed with 0 warnings and 0 errors and 370 tests; three `1.1.2` NuGet packages, win-x64/linux-x64 framework-dependent ZIPs, and the verified release manifest were created; packaged `doctor` and sample preview smoke passed; NuGet and GitHub Release dry-runs passed; bug-report privacy validation scanned 22 files; packaged `--version` and required-capability smoke passed; artifact-ignore checks and the prospective `Release 1.1.2` commit guard passed; and remote tag `v1.1.2` remained absent before publication. Release tracker #64 and the roadmap card moved to `Review / 75% / Release Tracker`.
 - `2026-07-10`: Completed the Avalonia `12.1.0` upgrade slice for release tracker #64. All repository-owned and dynamically generated PreviewHost test-project package references now use `12.1.0`; PreviewHost and Bridge screenshot saves use the new explicit PNG encoder options. `dotnet restore AvaScope.slnx` passed, `dotnet build AvaScope.slnx --no-restore -v:minimal` passed with 0 warnings and 0 errors, the full Debug suite passed with 370 tests, the resolved package graph verified 45 Avalonia 12 entries at `12.1.0`, no tracked active source/package reference remained on `12.0.4`, and `git diff --check` passed with only LF/CRLF normalization warnings.

--- a/docs/RELEASE_PLAN.md
+++ b/docs/RELEASE_PLAN.md
@@ -50,6 +50,33 @@ The roadmap below records the release-shaped plan through `v1.0.0`. It is intent
 - Every release must include targeted tests, full build/test validation, release dry-run validation, documentation updates, and explicit deferrals.
 - A release may be split into a patch release if a P0/P1 regression blocks users or CI, but patch scope must remain defect-focused.
 
+## In Progress Target: v1.1.3
+
+- Release: `v1.1.3`
+- Target Version: `1.1.3`
+- Release State: `In Progress`
+- Scope Lock: `2026-07-10`
+- GitHub Milestone: `v1.1.3`
+- GitHub Issues: #65, #66
+- Previous Release: `v1.1.2`
+
+### v1.1.3 Release Goals
+
+The `v1.1.3` patch release resolves the missing public license grant and package provenance metadata discovered before opening the source repository.
+
+1. `RG-1.1.3-1 Apache-2.0 License Grant`: license AvaScope-authored source and official release artifacts, including versions `0.1.0` and later, under Apache-2.0 while preserving third-party licenses.
+2. `RG-1.1.3-2 Verifiable Distribution Metadata`: embed license, repository, project, copyright, scope, and third-party notice data in NuGet and executable artifacts and validate the packed outputs.
+3. `RG-1.1.3-3 Guarded Patch Release`: publish only after the local release gate passes and the Release workflow creates `v1.1.3`, packages, executable ZIPs, manifest, and GitHub Release assets.
+
+### v1.1.3 Milestone Map
+
+- #65 `Add Apache-2.0 licensing and package provenance metadata`; Status: `Review`.
+- #66 `Release v1.1.3`; Status: `Ready`.
+
+### v1.1.3 Implementation Validation
+
+- `2026-07-10`: #65 added the canonical Apache-2.0 license and an explicit scope grant for AvaScope-authored official releases from `0.1.0` onward; packaged legal/provenance metadata is now verified for all NuGet packages and Windows/Linux executable ZIPs. Debug build passed with 0 warnings and 0 errors, focused stable-surface tests passed (`4`), the full Debug suite passed (`370`), Release package/ZIP generation with tests and sample smoke skipped passed the new artifact checks, NuGet and GitHub Release dry-runs passed, and `git diff --check` reported only line-ending normalization warnings.
+
 ## Released Target: v1.1.2
 
 - Release: `v1.1.2`

--- a/eng/package-executables.ps1
+++ b/eng/package-executables.ps1
@@ -102,6 +102,12 @@ if (-not (Test-IsUnderDirectory -Path $outputRootPath -Directory $repoRoot)) {
 }
 
 $projectPath = Join-Path $repoRoot "src/AvaScope.Cli/AvaScope.Cli.csproj"
+$legalFileNames = @(
+    "LICENSE",
+    "NOTICE",
+    "LICENSE-SCOPE.md",
+    "THIRD-PARTY-NOTICES.md"
+)
 
 New-Item -ItemType Directory -Path $outputRootPath -Force | Out-Null
 Assert-NoRunningOutputProcesses -OutputRootPath $outputRootPath
@@ -180,6 +186,13 @@ foreach ($runtimeIdentifier in $RuntimeIdentifiers) {
         throw "dotnet publish failed for $runtimeIdentifier with exit code $LASTEXITCODE."
     }
 
+    foreach ($legalFileName in $legalFileNames) {
+        Copy-Item `
+            -LiteralPath (Join-Path $repoRoot $legalFileName) `
+            -Destination (Join-Path $publishDirectory $legalFileName) `
+            -Force
+    }
+
     $appHostExtension = if ($runtimeIdentifier.StartsWith("win-", [System.StringComparison]::OrdinalIgnoreCase)) {
         ".exe"
     } else {
@@ -202,6 +215,7 @@ foreach ($runtimeIdentifier in $RuntimeIdentifiers) {
         "AvaScope.Core.dll",
         "AvaScope.Protocol.dll"
     )
+    $requiredFiles += $legalFileNames
 
     foreach ($file in $requiredFiles) {
         $path = Join-Path $publishDirectory $file

--- a/eng/verify-artifacts.ps1
+++ b/eng/verify-artifacts.ps1
@@ -8,6 +8,80 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+$requiredLegalFiles = @(
+    "LICENSE",
+    "NOTICE",
+    "LICENSE-SCOPE.md",
+    "THIRD-PARTY-NOTICES.md"
+)
+
+function Assert-NuGetPackageMetadata {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $nuspecEntries = @($archive.Entries | Where-Object { $_.FullName.EndsWith(".nuspec", [System.StringComparison]::OrdinalIgnoreCase) })
+        if ($nuspecEntries.Count -ne 1) {
+            throw "Expected exactly one nuspec in package: $Path"
+        }
+
+        $reader = [System.IO.StreamReader]::new($nuspecEntries[0].Open())
+        try {
+            [xml]$nuspec = $reader.ReadToEnd()
+        }
+        finally {
+            $reader.Dispose()
+        }
+
+        $metadata = $nuspec.package.metadata
+        if ($metadata.license.InnerText -ne "Apache-2.0" -or $metadata.license.type -ne "expression") {
+            throw "Package must declare Apache-2.0 as a license expression: $Path"
+        }
+
+        if ($metadata.projectUrl -ne "https://github.com/RolandUI/AvaScope") {
+            throw "Package projectUrl is missing or unexpected: $Path"
+        }
+
+        if ($metadata.repository.type -ne "git" -or $metadata.repository.url -ne "https://github.com/RolandUI/AvaScope.git") {
+            throw "Package repository metadata is missing or unexpected: $Path"
+        }
+
+        $entryNames = @($archive.Entries | ForEach-Object { $_.FullName.TrimEnd("/") })
+        foreach ($legalFileName in $requiredLegalFiles) {
+            if ($entryNames -notcontains $legalFileName) {
+                throw "Package is missing required legal file '$legalFileName': $Path"
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
+
+function Assert-ExecutableLegalFiles {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($Path)
+    try {
+        $entryNames = @($archive.Entries | ForEach-Object { $_.FullName.TrimEnd("/") })
+        foreach ($legalFileName in $requiredLegalFiles) {
+            if ($entryNames -notcontains $legalFileName) {
+                throw "Executable artifact is missing required legal file '$legalFileName': $Path"
+            }
+        }
+    }
+    finally {
+        $archive.Dispose()
+    }
+}
 
 function Test-IsUnderDirectory {
     param(
@@ -139,6 +213,14 @@ Get-ChildItem -LiteralPath $executableRootPath -Filter "avascope-*.zip" -File | 
     if (-not $expectedExecutableZipNames.ContainsKey($_.Name)) {
         throw "Unexpected executable ZIP artifact is not covered by the manifest: $($_.FullName)"
     }
+}
+
+foreach ($artifact in $requiredArtifacts | Where-Object { $_.Kind -eq "nuget-package" }) {
+    Assert-NuGetPackageMetadata -Path $artifact.Path
+}
+
+foreach ($artifact in $requiredArtifacts | Where-Object { $_.Kind -eq "executable-zip" }) {
+    Assert-ExecutableLegalFiles -Path $artifact.Path
 }
 
 $artifacts = foreach ($artifact in $requiredArtifacts) {

--- a/tests/AvaScope.Tests/Core/StableSurfaceContractTests.cs
+++ b/tests/AvaScope.Tests/Core/StableSurfaceContractTests.cs
@@ -147,6 +147,17 @@ public sealed class StableSurfaceContractTests
 
         var buildProps = XDocument.Load(Path.Combine(root, "Directory.Build.props"));
         Assert.Equal("net10.0", buildProps.Descendants("TargetFramework").Single().Value);
+        Assert.Equal("Apache-2.0", buildProps.Descendants("PackageLicenseExpression").Single().Value);
+        Assert.Equal("https://github.com/RolandUI/AvaScope", buildProps.Descendants("PackageProjectUrl").Single().Value);
+        Assert.Equal("https://github.com/RolandUI/AvaScope.git", buildProps.Descendants("RepositoryUrl").Single().Value);
+
+        foreach (var legalFileName in new[] { "LICENSE", "NOTICE", "LICENSE-SCOPE.md", "THIRD-PARTY-NOTICES.md" })
+        {
+            Assert.True(File.Exists(Path.Combine(root, legalFileName)), $"Missing required legal file: {legalFileName}");
+        }
+
+        var licenseScope = File.ReadAllText(Path.Combine(root, "LICENSE-SCOPE.md"));
+        Assert.Contains("versions 0.1.0 and later", licenseScope, StringComparison.Ordinal);
 
         var verifyArtifacts = File.ReadAllText(Path.Combine(root, "eng", "verify-artifacts.ps1"));
         Assert.Contains("AvaScope.Protocol.$version.nupkg", verifyArtifacts, StringComparison.Ordinal);
@@ -168,6 +179,12 @@ public sealed class StableSurfaceContractTests
         Assert.Contains("avascope.discovery.json", installer, StringComparison.Ordinal);
         Assert.Contains("avascope.cmd", installer, StringComparison.Ordinal);
         Assert.Contains("AvaScope.Mcp.dll", installer, StringComparison.Ordinal);
+
+        var packageExecutables = File.ReadAllText(Path.Combine(root, "eng", "package-executables.ps1"));
+        var verifyArtifactsScript = File.ReadAllText(Path.Combine(root, "eng", "verify-artifacts.ps1"));
+        Assert.Contains("THIRD-PARTY-NOTICES.md", packageExecutables, StringComparison.Ordinal);
+        Assert.Contains("Assert-NuGetPackageMetadata", verifyArtifactsScript, StringComparison.Ordinal);
+        Assert.Contains("Assert-ExecutableLegalFiles", verifyArtifactsScript, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add the canonical Apache License 2.0 and an explicit scope grant covering AvaScope-authored official releases from 0.1.0 onward
- add NuGet license, repository, project, and copyright metadata plus third-party notices
- package and verify legal files in NuGet packages and Windows/Linux executable ZIPs

## Why
The source repository and already published packages had no explicit public license grant or package license metadata. This makes the intended open-source use ambiguous.

## Validation
- `dotnet build AvaScope.slnx --no-restore -v:minimal` (0 warnings, 0 errors)
- focused stable-surface tests (4 passed)
- full Debug suite (370 passed)
- Release package/ZIP generation with tests and sample smoke skipped
- NuGet and GitHub Release dry-runs
- `git diff --check`

Closes #65